### PR TITLE
Address offenses from Rubocop

### DIFF
--- a/lib/sparkpost/client.rb
+++ b/lib/sparkpost/client.rb
@@ -6,11 +6,11 @@ module SparkPost
       @api_key = (api_key || ENV['SPARKPOST_API_KEY']).to_s
       @api_host = (api_host || ENV['SPARKPOST_API_HOST']).to_s
 
-      fail ArgumentError, 'No API key is provided. Either provide
+      raise ArgumentError, 'No API key is provided. Either provide
        api_key with constructor or set SPARKPOST_API_KEY environment
         variable' if @api_key.blank?
 
-      fail ArgumentError, 'No API host is provided. Either provide
+      raise ArgumentError, 'No API host is provided. Either provide
        api_host with constructor or set SPARKPOST_API_HOST environment
         variable' if @api_host.blank?
     end

--- a/lib/sparkpost/request.rb
+++ b/lib/sparkpost/request.rb
@@ -24,7 +24,7 @@ module SparkPost
     def process_response(response)
       response = JSON.parse(response.body)
       if response['errors']
-        fail SparkPost::DeliveryException, response['errors']
+        raise SparkPost::DeliveryException, response['errors']
       else
         response['results']
       end

--- a/lib/sparkpost/transmission.rb
+++ b/lib/sparkpost/transmission.rb
@@ -23,7 +23,7 @@ module SparkPost
       to = [to] unless to.is_a?(Array)
 
       if html_message.blank? && options[:text_message].blank?
-        fail ArgumentError, 'Content missing. Either provide html_message or
+        raise ArgumentError, 'Content missing. Either provide html_message or
          text_message in options parameter'
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,12 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require 'simplecov'
 require 'coveralls'
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
-  SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
-])
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+  [
+    SimpleCov::Formatter::HTMLFormatter,
+    Coveralls::SimpleCov::Formatter
+  ]
+)
 SimpleCov.start
 
 require 'webmock/rspec'


### PR DESCRIPTION
There were a few offenses from Rubocop causing the build to fail:

```
Running RuboCop...
Inspecting 20 files
........C.CC.......C

Offenses:

lib/sparkpost/client.rb:9:7: C: Always use raise to signal exceptions.
      fail ArgumentError, 'No API key is provided. Either provide
      ^^^^
lib/sparkpost/client.rb:13:7: C: Always use raise to signal exceptions.
      fail ArgumentError, 'No API host is provided. Either provide
      ^^^^
lib/sparkpost/request.rb:27:9: C: Always use raise to signal exceptions.
        fail SparkPost::DeliveryException, response['errors']
        ^^^^
lib/sparkpost/transmission.rb:26:9: C: Always use raise to signal exceptions.
        fail ArgumentError, 'Content missing. Either provide html_message or
        ^^^^
spec/spec_helper.rb:5:3: C: Use 2 spaces for indentation in an array, relative to the first position after the preceding left parenthesis.
  SimpleCov::Formatter::HTMLFormatter,
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/spec_helper.rb:7:1: C: Indent the right bracket the same as the first position after the preceding left parenthesis.
])
^

20 files inspected, 6 offenses detected
RuboCop failed!
```