### PR TITLE
Support full address specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Or install it yourself as:
 ```ruby
 require 'sparkpost'
 
-sp = SparkPost::Client.new() # api key was set in ENV
+sp = SparkPost::Client.new() # api key was set in ENV through ENV['SPARKPOST_API_KEY']
 response = sp.transmission.send_message('RECIPIENT_EMAIL', 'SENDER_EMAIL', 'test email', '<h1>HTML message</h1>')
 put response
 
@@ -60,11 +60,11 @@ require 'sparkpost'
 attachment = Base64.encode64(File.open(File.expand_path('../attachment.txt', __FILE__), 'r') { |f| f.read })
 
 # prepare attachment data to pass to send_message method
-values = { 
-    attachments: [{ 
-        name: 'attachment.txt', 
-        type: 'text/plain', 
-        data: attachment 
+values = {
+    attachments: [{
+        name: 'attachment.txt',
+        type: 'text/plain',
+        data: attachment
     }]
 }
 

--- a/lib/sparkpost/transmission.rb
+++ b/lib/sparkpost/transmission.rb
@@ -48,12 +48,16 @@ module SparkPost
     private
 
     def prepare_recipients(recipients)
-      recipients.map do |recipient|
-        {
-          address: {
-            email: recipient
-          }
-        }
+      recipients.map { |recipient| prepare_recipient(recipient) }
+    end
+
+    def prepare_recipient(recipient)
+      if recipient.is_a?(Hash)
+        raise ArgumentError,
+              "email missing - '#{recipient.inspect}'" unless recipient[:email]
+        { address: recipient }
+      else
+        { address: { email: recipient } }
       end
     end
   end

--- a/spec/lib/sparkpost/transmission_spec.rb
+++ b/spec/lib/sparkpost/transmission_spec.rb
@@ -63,6 +63,31 @@ RSpec.describe SparkPost::Transmission do
         '<h1>Hello World</h1>')
     end
 
+    it 'handles a recipient hash with email, name and header_to correctly' do
+      allow(transmission).to receive(:request) do |_url, _api_key, data|
+        expect(data[:recipients].length).to eq(1)
+        expect(data[:recipients][0][:address]).to eq(email: 'to@me.com',
+                                                     name: 'Me',
+                                                     header_to: 'no@reply.com'
+                                                    )
+      end
+      transmission.send_message(
+        { email: 'to@me.com', name: 'Me', header_to: 'no@reply.com' },
+        'from@example.com',
+        'test subject',
+        '<h1>Hello World</h1>')
+    end
+
+    it 'handles an invalid recipient hash' do
+      expect do
+        transmission.send_message(
+          { name: 'Me', header_to: 'no@reply.com' },
+          'from@example.com',
+          'test subject',
+          '<h1>Hello World</h1>')
+      end.to raise_error(/email missing/)
+    end
+
     it 'handles array of recipients correctly' do
       allow(transmission).to receive(:request) do |_url, _api_key, data|
         expect(data[:recipients].length).to eq(1)
@@ -73,6 +98,34 @@ RSpec.describe SparkPost::Transmission do
         'from@example.com',
         'test subject',
         '<h1>Hello World</h1>')
+    end
+
+    it 'handles array of recipient hashess correctly' do
+      allow(transmission).to receive(:request) do |_url, _api_key, data|
+        expect(data[:recipients].length).to eq(1)
+        expect(data[:recipients][0][:address]).to eq(email: 'to@me.com',
+                                                     name: 'Me',
+                                                     header_to: 'no@reply.com'
+                                                    )
+      end
+      transmission.send_message(
+        [{ email: 'to@me.com', name: 'Me', header_to: 'no@reply.com' }],
+        'from@example.com',
+        'test subject',
+        '<h1>Hello World</h1>')
+    end
+
+    it 'handles an array of invalid recipient hashes' do
+      expect do
+        transmission.send_message(
+          [
+            { to: 'to@me.com', name: 'Me', header_to: 'no@reply.com' },
+            { name: 'You', header_to: 'no@reply.com' }
+          ],
+          'from@example.com',
+          'test subject',
+          '<h1>Hello World</h1>')
+      end.to raise_error(/email missing/)
     end
 
     it do


### PR DESCRIPTION
According to https://developers.sparkpost.com/api/#/reference/recipient-lists 'Address Attributes' the SparkPost API supports more than just `email`, it also supports `name` and `header_to`.  I needed to set the `header_to` (to effectively send a BCC email) but noticed support was missing, so I added it :)