### PR TITLE
Allow Transmission#send_message to accept all params via options hash

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,7 @@ Documentation:
     Enabled: false
 Metrics/MethodLength:
   Enabled: false
+
+AllCops:
+  Exclude:
+    - './_examples/**/*'

--- a/lib/sparkpost/transmission.rb
+++ b/lib/sparkpost/transmission.rb
@@ -46,14 +46,18 @@ module SparkPost
       }
 
       options.merge!(options_from_args) { |_k, opts, _args| opts }
-      if options[:attachments].present?
-        options[:content][:attachments] = options.delete(:attachments)
-      end
+      add_attachments(options)
 
       request(endpoint, @api_key, options)
     end
 
     private
+
+    def add_attachments(options)
+      if options[:attachments].present?
+        options[:content][:attachments] = options.delete(:attachments)
+      end
+    end
 
     def prepare_recipients(recipients)
       recipients.map { |recipient| prepare_recipient(recipient) }

--- a/sparkpost.gemspec
+++ b/sparkpost.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.11.1'
   spec.add_development_dependency 'webmock', '~> 1.22.3'
   spec.add_development_dependency 'coveralls'
-  spec.add_development_dependency 'rubocop', '0.35.1'
+  spec.add_development_dependency 'rubocop', '~> 0.37.2'
 end

--- a/sparkpost.gemspec
+++ b/sparkpost.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.11.1'
   spec.add_development_dependency 'webmock', '~> 1.22.3'
   spec.add_development_dependency 'coveralls'
-  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubocop', '0.35.1'
 end


### PR DESCRIPTION
This PR extends the functionality of `Transmission#send_message` to allow all the parameters to be passed in via the options hash. This would allow a payload to be constructed which conforms to the [API specifications](https://developers.sparkpost.com/api/?_ga=1.242735810.1770884618.1456768120#/reference/transmissions), which I believe would make the interface more consistent.

For example, you can currently send a message like so:
```ruby
      transmission.send_message(
        { email: 'to@me.com', name: 'Me', header_to: 'no@reply.com' },
        'from@example.com',
        'test subject',
        '<h1>Hello World</h1>')
```

This PR maintains the above functionality, but allows you to also do:
```ruby
      data = {
        recipients: [
          { address: { email: 'to@me.com', name: 'Me', header_to: 'no@reply.com' } }
        ],
        content: {
          from: { email: 'me@me.com', name: 'Me' },
          subject: 'test subject',
          text: 'Hello Sparky',
          html: '<h1>Hello Sparky</h1>',
        }
      }
      transmission.send_message(data)
```

I've also added two new tests that:
* Verify that all params can be passed in the options hash
* Verify that in the event of a parameter being defined in the traditional way _and_ in the options hash, the parameter from the options hash will be used.

Looking forward to hearing your feedback!