### PR TITLE
simplify logic to be able to send arbitrary request

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,9 @@ Documentation:
 Metrics/MethodLength:
   Enabled: false
 
+Metrics/LineLength:
+  Exclude:
+    - spec/**/*
 AllCops:
   Exclude:
-    - './_examples/**/*'
+    - _examples/**/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.1.2
   - 2.2.4
   - 2.3.0
+  - ruby-head
 notifications:
   slack:
     secure: VNIwgvrbcwj0b2gfYSOeTyK7rkV62/belwhYthasHmN+DoTsEJF4+HFVtzOykS72LM/f5Id5zieWtxYG+soy+yEOc1iZizXRpRJORtTYfZJB9RCffavosl322BcpoTX99cGyiZjWjOFH70UWlFMB3zT0jS+9icuTfk7ZqBX/zDA=

--- a/examples/transmission/with_template.rb
+++ b/examples/transmission/with_template.rb
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+require_relative '../../lib/sparkpost'
+
+# prepare the payload as required by SparkPost API endpoint
+payload = {
+  recipients: [{ address: { email: 'RECIPIENT_EMAIL' } }],
+  content: {
+    from: 'SENDER_EMAIL',
+    subject: 'test email',
+    template_id: 'YOUR_TEMPLATE_ID'
+  }
+}
+
+sp = SparkPost::Client.new # api key was set in ENV
+response = sp.transmission.send_payload(payload)
+
+puts response

--- a/lib/sparkpost/transmission.rb
+++ b/lib/sparkpost/transmission.rb
@@ -20,8 +20,9 @@ module SparkPost
 
     def send_payload(data = {})
       # TODO: consider refactoring this into send_message in v2
-      send_message(nil, nil, nil, nil, data)
+      request(endpoint, @api_key, data)
     end
+
 
     def send_message(to, from, subject, html_message = nil, **options)
       # TODO: add validations for to, from

--- a/lib/sparkpost/transmission.rb
+++ b/lib/sparkpost/transmission.rb
@@ -48,7 +48,7 @@ module SparkPost
       options.merge!(options_from_args) { |_k, opts, _args| opts }
       add_attachments(options)
 
-      request(endpoint, @api_key, options)
+      send_payload(options)
     end
 
     private

--- a/lib/sparkpost/transmission.rb
+++ b/lib/sparkpost/transmission.rb
@@ -23,7 +23,6 @@ module SparkPost
       request(endpoint, @api_key, data)
     end
 
-
     def send_message(to, from, subject, html_message = nil, **options)
       # TODO: add validations for to, from
       to = [to] unless to.is_a?(Array)


### PR DESCRIPTION
Allow send_payload to send prepared content as is. 