### PR TITLE
correct typo: put → puts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ require 'sparkpost'
 
 sp = SparkPost::Client.new() # api key was set in ENV through ENV['SPARKPOST_API_KEY']
 response = sp.transmission.send_message('RECIPIENT_EMAIL', 'SENDER_EMAIL', 'test email', '<h1>HTML message</h1>')
-put response
+puts response
 
 # {"total_rejected_recipients"=>0, "total_accepted_recipients"=>1, "id"=>"123456789123456789"}
 ```


### PR DESCRIPTION
The method `put` does not exists. The correct method should be `puts`.