### PR TITLE
Recipients public method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ rvm:
   - 2.1.2
   - 2.2.4
   - 2.3.0
-  - ruby-head
 notifications:
   slack:
     secure: VNIwgvrbcwj0b2gfYSOeTyK7rkV62/belwhYthasHmN+DoTsEJF4+HFVtzOykS72LM/f5Id5zieWtxYG+soy+yEOc1iZizXRpRJORtTYfZJB9RCffavosl322BcpoTX99cGyiZjWjOFH70UWlFMB3zT0jS+9icuTfk7ZqBX/zDA=

--- a/lib/sparkpost/transmission.rb
+++ b/lib/sparkpost/transmission.rb
@@ -56,6 +56,7 @@ module SparkPost
     end
 
     private
+
     def add_attachments(options)
       if options[:attachments].present?
         options[:content][:attachments] = options.delete(:attachments)

--- a/lib/sparkpost/transmission.rb
+++ b/lib/sparkpost/transmission.rb
@@ -25,7 +25,6 @@ module SparkPost
 
     def send_message(to, from, subject, html_message = nil, **options)
       # TODO: add validations for to, from
-      to = [to] unless to.is_a?(Array)
       html_message = content_from(options, :html) || html_message
       text_message = content_from(options, :text) || options[:text_message]
 
@@ -51,16 +50,16 @@ module SparkPost
       send_payload(options)
     end
 
-    private
+    def prepare_recipients(recipients)
+      recipients = [recipients] unless recipients.is_a?(Array)
+      recipients.map { |recipient| prepare_recipient(recipient) }
+    end
 
+    private
     def add_attachments(options)
       if options[:attachments].present?
         options[:content][:attachments] = options.delete(:attachments)
       end
-    end
-
-    def prepare_recipients(recipients)
-      recipients.map { |recipient| prepare_recipient(recipient) }
     end
 
     def prepare_recipient(recipient)


### PR DESCRIPTION
Making `prepare_recipients` a public method which can be used for easily preparing payload (to be sent in `send_payload` method)

Remove `ruby-head` as it prune to failure. 