### PR TITLE
Change to_json to JSON.generate on request

### DIFF
--- a/lib/sparkpost/request.rb
+++ b/lib/sparkpost/request.rb
@@ -16,7 +16,7 @@ module SparkPost
         'Authorization' => api_key
       }
       req = Net::HTTP::Post.new(uri.path, headers)
-      req.body = data.to_json
+      req.body = JSON.generate(data)
 
       process_response(http.request(req))
     end

--- a/spec/lib/sparkpost/request_spec.rb
+++ b/spec/lib/sparkpost/request_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe SparkPost::Request do
       }
       before do
         stub_request(:post, api_url).to_return(
-          body: response.to_json,
+          body: JSON.generate(response),
           status: 200)
       end
       it do
@@ -29,7 +29,7 @@ RSpec.describe SparkPost::Request do
       response = { errors: { message: 'end of world' } }
       before do
         stub_request(:post, api_url).to_return(
-          body: response.to_json,
+          body: JSON.generate(response),
           status: 500)
       end
 


### PR DESCRIPTION
When using inside rails, the `.to_json` generates a string with utf-8 escapes like:

```
"\"\\u003Ch1\\u003EHTML message 2\\u003C/h1\\u003E \\u003Cp\\u003Eline2 \\u003Cp\\u003E\""`
```

This raises the following error:
```
"message" => "invalid data format/type",
"description" => "Problems parsing request as json",
"code" => "1300"
```
Using `JSON.generate` solves the problem:

```
"<h1>HTML message 2</h1> <p>line2 <p>"`
```