### PR TITLE
Complete Templates wrapper

### DIFF
--- a/lib/sparkpost/helpers.rb
+++ b/lib/sparkpost/helpers.rb
@@ -1,0 +1,23 @@
+require_relative '../core_extensions/object'
+
+module SparkPost
+  module Helpers
+    def copy_value(src_hash, src_key, dst_hash, dst_key)
+      dst_hash[dst_key] = src_hash[src_key] if src_hash.key?(src_key)
+    end
+
+    def deep_merge(source_hash, other_hash)
+      source_hash.merge(other_hash) do |_key, oldval, newval|
+        if newval.respond_to?(:blank?) && newval.blank?
+          oldval
+        elsif oldval.is_a?(Hash) && newval.is_a?(Hash)
+          deep_merge(oldval, newval)
+        else
+          newval
+        end
+      end
+    end
+
+    module_function :copy_value, :deep_merge
+  end
+end

--- a/lib/sparkpost/request.rb
+++ b/lib/sparkpost/request.rb
@@ -18,6 +18,19 @@ module SparkPost
       process_response(http.request(req))
     end
 
+    def endpoint(subpath = nil, params = {})
+      url = String.new(@base_endpoint)
+      if subpath
+        url << '/' unless subpath.start_with?('/')
+        url << subpath
+      end
+      if params && params.any?
+        url << '?'
+        url << params.to_a.map { |x| "#{x[0]}=#{x[1]}" }.join('&')
+      end
+      url
+    end
+
     def configure_http(uri)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
@@ -31,7 +44,7 @@ module SparkPost
             when 'PUT'
               Net::HTTP::Put.new(uri.path, headers)
             when 'DELETE'
-              Net::HTTP::Delete.new(uri.path)
+              Net::HTTP::Delete.new(uri.path, headers)
             else
               Net::HTTP::Post.new(uri.path, headers)
             end

--- a/lib/sparkpost/template.rb
+++ b/lib/sparkpost/template.rb
@@ -3,23 +3,110 @@ require 'uri'
 require 'http'
 require_relative '../core_extensions/object'
 require_relative 'request'
+require_relative 'helpers'
 require_relative 'exceptions'
 
 module SparkPost
   class Template
     include Request
+    include Helpers
 
     def initialize(api_key, api_host)
       @api_key = api_key
       @api_host = api_host
+      @base_endpoint = "#{@api_host}/api/v1/templates"
     end
 
-    def endpoint
-      @endpoint ||= @api_host.concat('/api/v1/templates')
+    def create(id, from = nil, subject = nil, html = nil, **options)
+      data = deep_merge(
+        payload_from_args(id, from, subject, html),
+        payload_from_options(options)
+      )
+      request(endpoint, @api_key, data, 'POST')
+    end
+
+    def update(id, from = nil, subject = nil, html = nil, **options)
+      data = deep_merge(
+        payload_from_args(nil, from, subject, html),
+        payload_from_options(options)
+      )
+      request(endpoint(id), @api_key, data, 'PUT')
+    end
+
+    def delete(id)
+      request(endpoint(id), @api_key, nil, 'DELETE')
+    end
+
+    def get(id, draft = nil)
+      params = {}
+      params[:draft] = draft unless draft.nil?
+      request(endpoint(id, params), @api_key, nil, 'GET')
     end
 
     def list
       request(endpoint, @api_key, nil, 'GET')
+    end
+
+    def preview(id, substitution_data, draft = nil)
+      params = {}
+      params[:draft] = draft unless draft.nil?
+      request(
+        endpoint("#{id}/preview", params),
+        @api_key,
+        { substitution_data: substitution_data },
+        'POST'
+      )
+    end
+
+    private
+
+    def payload_from_args(id, from, subject, html)
+      model = { content: {}, options: {} }
+
+      model[:id] = id unless id.nil?
+      model[:content][:from] = from unless from.nil?
+      model[:content][:subject] = subject unless subject.nil?
+      model[:content][:html] = html unless html.nil?
+
+      model
+    end
+
+    def payload_from_options(**options)
+      model = { content: { from: {} }, options: {} }
+
+      # Mapping optional arguments to root
+      [
+        [:name, :name],
+        [:id, :id],
+        [:description, :description],
+        [:published, :published]
+      ].each { |skey, dkey| copy_value(options, skey, model, dkey) }
+
+      # Mapping optional arguments to options
+      [
+        [:track_opens, :open_tracking],
+        [:track_clicks, :click_tracking],
+        [:is_transactional, :transactional]
+      ].each { |skey, dkey| copy_value(options, skey, model[:options], dkey) }
+
+      # Mapping optional arguments to content
+      [
+        [:html, :html],
+        [:text, :text],
+        [:subject, :subject],
+        [:reply_to, :reply_to],
+        [:custom_headers, :headers]
+      ].each { |skey, dkey| copy_value(options, skey, model[:content], dkey) }
+
+      # Mapping optional arguments to sender information
+      [
+        [:from_email, :email],
+        [:from_name, :name]
+      ].each do |skey, dkey|
+        copy_value(options, skey, model[:content][:from], dkey)
+      end
+
+      model
     end
   end
 end

--- a/lib/sparkpost/transmission.rb
+++ b/lib/sparkpost/transmission.rb
@@ -12,10 +12,7 @@ module SparkPost
     def initialize(api_key, api_host)
       @api_key = api_key
       @api_host = api_host
-    end
-
-    def endpoint
-      @endpoint ||= @api_host.concat('/api/v1/transmissions')
+      @base_endpoint = "#{@api_host}/api/v1/transmissions"
     end
 
     def send_payload(data = {})

--- a/spec/lib/sparkpost/helpers_spec.rb
+++ b/spec/lib/sparkpost/helpers_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+
+RSpec.describe SparkPost::Helpers do
+  let(:helpers) { SparkPost::Helpers }
+
+  describe '#copy_value' do
+    context 'when source is empty' do
+      let(:src_hash) { {} }
+      let(:dst_hash) { { dkey: 'val' } }
+
+      copied_hash = { dkey: 'val' }
+
+      it 'does not copy values' do
+        helpers.copy_value(src_hash, :skey, dst_hash, :dkey)
+        expect(dst_hash).to eq(copied_hash)
+      end
+    end
+
+    context 'when source is not empty' do
+      let(:src_hash) { { skey: 'val' } }
+      let(:dst_hash) { {} }
+
+      copied_hash = { dkey: 'val' }
+
+      it 'copies values' do
+        helpers.copy_value(src_hash, :skey, dst_hash, :dkey)
+        expect(dst_hash).to eq(copied_hash)
+      end
+    end
+  end
+
+  describe '#deep_merge' do
+    context 'when source_hash and other_hash have different keys' do
+      let(:source_hash) { { key1: 'val1', key2: 'val2' } }
+      let(:other_hash) { { key3: 'val3', key4: 'val4' } }
+
+      merged_hash = {
+        key1: 'val1',
+        key2: 'val2',
+        key3: 'val3',
+        key4: 'val4'
+      }
+
+      it 'merges source_hash and other_hash' do
+        expect(helpers.deep_merge(source_hash, other_hash)).to eq(merged_hash)
+      end
+    end
+
+    context 'when other_hash has nil value' do
+      let(:source_hash) { { key1: 'val1', key2: 'val2' } }
+      let(:other_hash) { { key1: nil } }
+
+      merged_hash = {
+        key1: 'val1',
+        key2: 'val2'
+      }
+
+      it 'merges source_hash and other_hash' do
+        expect(helpers.deep_merge(source_hash, other_hash)).to eq(merged_hash)
+      end
+    end
+
+    context 'when source_hash has nil value' do
+      let(:source_hash) { { key1: nil } }
+      let(:other_hash) { { key1: 'val1', key2: 'val2' } }
+
+      merged_hash = {
+        key1: 'val1',
+        key2: 'val2'
+      }
+
+      it 'merges source_hash and other_hash' do
+        expect(helpers.deep_merge(source_hash, other_hash)).to eq(merged_hash)
+      end
+    end
+
+    context 'when source_hash and other_hash have nested hash' do
+      let(:source_hash) { { key1: { s1: 'sv1' } } }
+      let(:other_hash) { { key1: { s2: 'sv2' }, key2: 'val2' } }
+
+      merged_hash = {
+        key1: { s1: 'sv1', s2: 'sv2' },
+        key2: 'val2'
+      }
+
+      it 'merges source_hash and other_hash' do
+        expect(helpers.deep_merge(source_hash, other_hash)).to eq(merged_hash)
+      end
+    end
+  end
+end

--- a/spec/lib/sparkpost/template_spec.rb
+++ b/spec/lib/sparkpost/template_spec.rb
@@ -16,11 +16,11 @@ RSpec.describe SparkPost::Template do
     end
 
     context 'when api key or host not passed' do
-      it do
+      it 'raises when api key and host not passed' do
         expect { SparkPost::Template.new }
           .to raise_error(ArgumentError)
       end
-      it do
+      it 'raises when host not passed' do
         expect { SparkPost::Template.new(123) }
           .to raise_error(ArgumentError)
       end
@@ -44,6 +44,136 @@ RSpec.describe SparkPost::Template do
     end
   end
 
+  describe '#create' do
+    let(:template) do
+      SparkPost::Template.new('123456', 'https://api.sparkpost.com')
+    end
+    let(:url) { 'https://api.sparkpost.com/api/v1/templates' }
+
+    it 'calls request with correct data' do
+      prepared_data = {
+        content: {
+          from: 'me@me.com',
+          subject: 'test subject',
+          text: 'Hello Sparky',
+          html: '<h1>Hello Sparky</h1>'
+        },
+        options: {
+          transactional: true
+        },
+        id: 'sample-template',
+        name: 'Sample Template'
+      }
+
+      allow(template).to receive(:request) do |req_url, req_api_key, req_data, req_verb|
+        expect(req_verb).to eq('POST')
+        expect(req_api_key).to eq('123456')
+        expect(req_url).to eq(url)
+        expect(req_data).to eq(prepared_data)
+      end
+
+      template.create(
+        'sample-template',
+        'me@me.com',
+        'test subject',
+        '<h1>Hello Sparky</h1>',
+        text: 'Hello Sparky',
+        is_transactional: true,
+        name: 'Sample Template'
+      )
+    end
+  end
+
+  describe '#update' do
+    let(:template) do
+      SparkPost::Template.new('123456', 'https://api.sparkpost.com')
+    end
+    let(:url) { 'https://api.sparkpost.com/api/v1/templates/sample-template' }
+
+    it 'calls request with correct data' do
+      prepared_data = {
+        content: {
+          from: 'me@me.com',
+          subject: 'test subject',
+          text: 'Hello Sparky',
+          html: '<h1>Hello Sparky</h1>'
+        },
+        options: {
+          transactional: true
+        }
+      }
+
+      allow(template).to receive(:request) do |req_url, req_api_key, req_data, req_verb|
+        expect(req_verb).to eq('PUT')
+        expect(req_api_key).to eq('123456')
+        expect(req_url).to eq(url)
+        expect(req_data).to eq(prepared_data)
+      end
+
+      template.update(
+        'sample-template',
+        'me@me.com',
+        'test subject',
+        '<h1>Hello Sparky</h1>',
+        text: 'Hello Sparky',
+        is_transactional: true
+      )
+    end
+  end
+
+  describe '#delete' do
+    let(:template) do
+      SparkPost::Template.new('123456', 'https://api.sparkpost.com')
+    end
+    let(:url) { 'https://api.sparkpost.com/api/v1/templates/sample-template' }
+
+    it 'calls request with correct data' do
+      allow(template).to receive(:request) do |req_url, req_api_key, _req_data, req_verb|
+        expect(req_verb).to eq('DELETE')
+        expect(req_api_key).to eq('123456')
+        expect(req_url).to eq(url)
+      end
+
+      template.delete('sample-template')
+    end
+  end
+
+  describe '#get' do
+    let(:template) do
+      SparkPost::Template.new('123456', 'https://api.sparkpost.com')
+    end
+
+    let(:template_id) { 'my-email-template' }
+
+    context 'when retrieve published template' do
+      let(:url) { "https://api.sparkpost.com/api/v1/templates/#{template_id}" }
+
+      it 'calls request with correct data' do
+        allow(template).to receive(:request) do |req_url, req_api_key, _req_data, req_verb|
+          expect(req_verb).to eq('GET')
+          expect(req_api_key).to eq('123456')
+          expect(req_url).to eq(url)
+        end
+
+        template.get(template_id)
+      end
+    end
+
+    context 'when retrieve draft template' do
+      let(:url) { "https://api.sparkpost.com/api/v1/templates/#{template_id}?draft=true" }
+
+      it 'calls request with correct data' do
+        allow(template).to receive(:request) do |req_url, req_api_key, _req_data, req_verb|
+          expect(req_verb).to eq('GET')
+          expect(req_api_key).to eq('123456')
+          expect(req_url).to eq(url)
+        end
+
+        template.get(template_id, true)
+      end
+    end
+  end
+
   describe '#list' do
     let(:template) do
       SparkPost::Template.new('123456', 'https://api.sparkpost.com')
@@ -58,6 +188,44 @@ RSpec.describe SparkPost::Template do
       end
 
       template.list
+    end
+  end
+
+  describe '#preview' do
+    let(:template) do
+      SparkPost::Template.new('123456', 'https://api.sparkpost.com')
+    end
+
+    let(:template_id) { 'my-email-template' }
+
+    context 'when retrieve published template' do
+      let(:url) { "https://api.sparkpost.com/api/v1/templates/#{template_id}/preview" }
+
+      it 'calls request with correct data' do
+        allow(template).to receive(:request) do |req_url, req_api_key, req_data, req_verb|
+          expect(req_verb).to eq('POST')
+          expect(req_api_key).to eq('123456')
+          expect(req_data).to eq(substitution_data: {})
+          expect(req_url).to eq(url)
+        end
+
+        template.preview(template_id, {})
+      end
+    end
+
+    context 'when retrieve draft template' do
+      let(:url) { "https://api.sparkpost.com/api/v1/templates/#{template_id}/preview?draft=true" }
+
+      it 'calls request with correct data' do
+        allow(template).to receive(:request) do |req_url, req_api_key, req_data, req_verb|
+          expect(req_verb).to eq('POST')
+          expect(req_api_key).to eq('123456')
+          expect(req_data).to eq(substitution_data: {})
+          expect(req_url).to eq(url)
+        end
+
+        template.preview(template_id, {}, true)
+      end
     end
   end
 end


### PR DESCRIPTION
I completed `Template` wrapper by  adding some methods (`create`, `get`, `update`, `delete`, `preview`). I noticed there are bug in `request` method: missing HTTP headers in `DELETE` verb and null `data` handling.

Btw, should we use plural (`templates` or `transmissions`) like in Python instead of singular form?