### PR TITLE
Allow additional user defined content options

### DIFF
--- a/lib/sparkpost/transmission.rb
+++ b/lib/sparkpost/transmission.rb
@@ -23,6 +23,7 @@ module SparkPost
       # TODO: add validations for to, from
       html_message = content_from(options, :html) || html_message
       text_message = content_from(options, :text) || options[:text_message]
+      content_options = options.delete(:content) || {}
 
       if html_message.blank? && text_message.blank?
         raise ArgumentError, 'Content missing. Either provide html_message or
@@ -31,12 +32,12 @@ module SparkPost
 
       options_from_args = {
         recipients: prepare_recipients(to),
-        content: {
+        content: content_options.merge(
           from: from,
           subject: subject,
           text: options.delete(:text_message),
           html: html_message
-        },
+        ),
         options: {}
       }
 

--- a/spec/lib/sparkpost/transmission_spec.rb
+++ b/spec/lib/sparkpost/transmission_spec.rb
@@ -132,6 +132,28 @@ RSpec.describe SparkPost::Transmission do
       )
     end
 
+    it 'allows user to specify addtional content attributes' do
+      expected_content = {
+        from: 'me@me.com',
+        subject: 'test subject',
+        text: nil,
+        html: '<h1>Hello Sparky</h1>',
+        reply_to: 'you@you.com'
+      }
+
+      expect(transmission).to receive(:send_payload) do |payload|
+        expect(payload[:content]).to eq(expected_content)
+      end
+
+      transmission.send_message(
+        'to@me.com',
+        'me@me.com',
+        'test subject',
+        '<h1>Hello Sparky</h1>',
+        content: { reply_to: 'you@you.com', subject: 'rogue subject' }
+      )
+    end
+
     it 'requests correct endpoint' do
       allow(transmission).to receive(:request) do |request_url|
         expect(request_url).to eq(url)


### PR DESCRIPTION
In the transmission send_message request allow the user to specify additional
options for the content hash. But merge these options in with the defaults
provided rather than just take whatever the user provides and throw away
the defaults.
Example attribute: `reply_to`

https://developers.sparkpost.com/api/#/reference/transmissions