### PR TITLE
Allow searching of suppression lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ sp = SparkPost::Client.new() # pass api key or get api key from ENV
 sp.transmission.send_message('RECIPIENT_EMAIL', 'SENDER_EMAIL', 'testemail', '<h1>Email with an attachment</h1>', values)
 ```
 
+**Search the suppression list**
+
+```ruby
+require 'sparkpost'
+
+sp = SparkPost::Client.new() # pass api key or get api key from ENV
+sp.suppression_list.search
+```
+
+
 See: [examples](examples)
 
 ## Development

--- a/examples/suppression_list/search.rb
+++ b/examples/suppression_list/search.rb
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+
+require_relative '../../lib/sparkpost'
+
+sp = SparkPost::Client.new # pass api key or get api key from ENV
+response = sp.suppression_list.search
+
+puts response

--- a/lib/sparkpost.rb
+++ b/lib/sparkpost.rb
@@ -1,4 +1,5 @@
 require_relative 'sparkpost/version'
 require_relative 'sparkpost/transmission'
+require_relative 'sparkpost/suppression_list'
 require_relative 'sparkpost/client'
 require_relative 'sparkpost/template'

--- a/lib/sparkpost/client.rb
+++ b/lib/sparkpost/client.rb
@@ -22,5 +22,9 @@ module SparkPost
     def template
       @template ||= Template.new(@api_key, @api_host)
     end
+
+    def suppression_list
+      @suppression_list ||= SuppressionList.new(@api_key, @api_host)
+    end
   end
 end

--- a/lib/sparkpost/suppression_list.rb
+++ b/lib/sparkpost/suppression_list.rb
@@ -1,0 +1,35 @@
+require 'net/http'
+require 'uri'
+require_relative '../core_extensions/object'
+require_relative 'request'
+
+module SparkPost
+  class SuppressionList
+    include Request
+
+    def initialize(api_key, api_host)
+      @api_key       = api_key
+      @api_host      = api_host
+      @base_endpoint = "#{@api_host}/api/v1/suppression-list".freeze
+    end
+
+    def search(from: nil, to: nil, types: nil, sources: nil, limit: nil)
+      params = {
+        to: to,
+        from: from,
+        types: array_params(types),
+        sources: array_params(sources),
+        limit: limit
+      }.reject { |_, v| v.nil? }
+
+      url = endpoint(nil, params)
+      request(url, @api_key, {}, 'GET')
+    end
+
+    private
+
+    def array_params(param)
+      param.is_a?(Array) ? param.join(',') : param
+    end
+  end
+end

--- a/spec/lib/sparkpost/client_spec.rb
+++ b/spec/lib/sparkpost/client_spec.rb
@@ -55,4 +55,14 @@ RSpec.describe SparkPost::Transmission do
       expect(client.template).to eq(client.template)
     end
   end
+
+  describe '#suppression_list' do
+    let(:client) { SparkPost::Client.new('123', 'http://sparkpost.com') }
+
+    it { expect(client.suppression_list).to be_kind_of(SparkPost::SuppressionList) }
+
+    it 'returns same instances on subsequent call' do
+      expect(client.suppression_list).to eq(client.suppression_list)
+    end
+  end
 end

--- a/spec/lib/sparkpost/suppression_list_spec.rb
+++ b/spec/lib/sparkpost/suppression_list_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+
+RSpec.describe SparkPost::SuppressionList do
+  describe '#initialize' do
+    context 'when api key and host are passed'
+    let(:suppression_list) do
+      SparkPost::Template.new('123', 'http://sparkpost.com')
+    end
+
+    it { expect(suppression_list.instance_variables).to include(:@api_key) }
+    it { expect(suppression_list.instance_variables).to include(:@api_host) }
+    it { expect(suppression_list.instance_variable_get(:@api_key)).to eq('123') }
+    it do
+      expect(suppression_list.instance_variable_get(:@api_host))
+        .to eq('http://sparkpost.com')
+    end
+
+    context 'when api key or host not passed' do
+      it 'raises when api key and host not passed' do
+        expect { SparkPost::SuppressionList.new }
+          .to raise_error(ArgumentError)
+      end
+      it 'raises when host not passed' do
+        expect { SparkPost::SuppressionList.new(123) }
+          .to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe '#endpoint' do
+    let(:suppression_list) do
+      SparkPost::SuppressionList.new('123456', 'https://api.sparkpost.com')
+    end
+    let(:url) { 'https://api.sparkpost.com/api/v1/suppression-list' }
+
+    it 'returns correct endpoint' do
+      expect(suppression_list.endpoint).to eq(url)
+    end
+
+    it 'returns correct endpoint on subsequent calls' do
+      suppression_list.endpoint
+
+      expect(suppression_list.endpoint).to eq(url)
+    end
+  end
+
+  describe '#search' do
+    let(:suppression_list) do
+      SparkPost::SuppressionList.new('123456', 'https://api.sparkpost.com')
+    end
+
+    it 'calls request with correct params when there are array values' do
+      allow(suppression_list).to receive(:request) do |req_url, req_api_key, req_data, req_verb|
+        expect(req_url).to eq('https://api.sparkpost.com/api/v1/suppression-list?to=t&from=f&types=t,T&sources=s,S&limit=5')
+        expect(req_api_key).to eq('123456')
+        expect(req_data).to eq({})
+        expect(req_verb).to eq('GET')
+      end
+
+      suppression_list.search(from: 'f', to: 't', types: %w(t T), sources: %w(s S), limit: '5')
+    end
+
+    it 'calls request with correct params when there are single values' do
+      allow(suppression_list).to receive(:request) do |req_url, req_api_key, req_data, req_verb|
+        expect(req_url).to eq('https://api.sparkpost.com/api/v1/suppression-list?to=t&from=f&types=t&sources=t&limit=5')
+        expect(req_api_key).to eq('123456')
+        expect(req_data).to eq({})
+        expect(req_verb).to eq('GET')
+      end
+
+      suppression_list.search(from: 'f', to: 't', types: 't', sources: 't', limit: '5')
+    end
+
+    it 'calls request with the correct params when there are no values' do
+      allow(suppression_list).to receive(:request) do |req_url, req_api_key, req_data, req_verb|
+        expect(req_url).to eq('https://api.sparkpost.com/api/v1/suppression-list')
+        expect(req_api_key).to eq('123456')
+        expect(req_data).to eq({})
+        expect(req_verb).to eq('GET')
+      end
+
+      suppression_list.search
+    end
+  end
+end


### PR DESCRIPTION
Why:

* SparkPost raises an exception when sending to a suppressed email
* We need the ability to monitor who we should and shouldn't send to

This change addresses the need by:

* Adding a method to search for suppressed emails